### PR TITLE
Add CI workflow for .NET project build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: ci
+
+on:
+  push:
+    branches: [ "master", "release/**" ]
+  pull_request:
+    branches: [ "master", "release/**" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    - uses: dotnet/nbgv@v0.4.2
+      name: NBGV
+      id: nbgv
+      with:
+        setAllVars: "true"
+
+    - name: Build Packages
+      run: dotnet build src/Uno.DebugRainbows/Uno.DebugRainbows.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
       id: nbgv
       with:
         setAllVars: "true"
-
+    - name: Generate Informational Version
+      id: NBGV_InformationalVersion
+      shell: pwsh
+      run: |
+        $InformationalVersion="${{ steps.nbgv.outputs.SemVer2 }}+${{ steps.nbgv.outputs.BuildingRef }}".Replace("refs/heads/","").Replace("/","-")
+        echo "Informational Version: $InformationalVersion"
+        echo "NBGV_InformationalVersion=$InformationalVersion" >> $GITHUB_ENV
     - name: Build Packages
-      run: dotnet build src/Uno.DebugRainbows/Uno.DebugRainbows.csproj
+      run: |
+        $adjustedPackageVersion="${{ steps.nbgv.outputs.SemVer2 }}".ToLower();
+        dotnet build src/Uno.DebugRainbows/Uno.DebugRainbows.csproj -c Release -p:PackageVersion=$adjustedPackageVersion -p:Version=${{ steps.nbgv.outputs.SimpleVersion }} /bl:./artifacts/debugrainbows-pack.binlog -o ./artifacts
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: ./artifacts

--- a/version.json
+++ b/version.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0-dev.{height}",
+  "nuGetPackageVersion": {
+    "semVer": 2.0
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "setAllVariables": true,
+    "buildNumber": {
+      "enabled": true
+    }
+  },
+  "release": {
+    "branchName": "release/stable/{version}",
+    "firstUnstableTag": "dev"
+  }
+}


### PR DESCRIPTION
This pull request introduces continuous integration (CI) support for the project by adding a GitHub Actions workflow for building and packaging the .NET project, and sets up automated versioning using Nerdbank.GitVersioning. These changes help automate builds, manage versioning, and streamline releases.

**CI/CD and Build Automation:**

* Added a `.github/workflows/ci.yml` workflow that triggers on pushes and pull requests to `master` and `release/**` branches. The workflow checks out the code, sets up .NET 9.0, runs Nerdbank.GitVersioning (NBGV) to manage versioning, builds the project, and uploads build artifacts as NuGet packages.

**Automated Versioning:**

* Introduced a `version.json` file to configure Nerdbank.GitVersioning, enabling automatic semantic versioning, setting up public release branch specifications, and configuring cloud build variables and release branch naming conventions.