### PR TITLE
adjust nuget publishing

### DIFF
--- a/.github/actions/nuget-org-publish/action.yml
+++ b/.github/actions/nuget-org-publish/action.yml
@@ -1,0 +1,23 @@
+name: "Deploy to nuget.org"
+description: "Deploy to nuget.org"
+
+inputs:
+  token:
+    description: "The token to use for nuget publishing"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+  - name: Download Artifacts
+    uses: actions/download-artifact@v4
+    with:
+        name: NuGet-Signed
+        path: artifacts
+
+  - name: NuGet.org Push
+    shell: pwsh
+    run: |
+        dotnet nuget push artifacts/*.nupkg -s https://api.nuget.org/v3/index.json -k "${{ inputs.token }}"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: ci
+
+on:
+  push:
+    branches: [ "master", "release/**" ]
+  pull_request:
+    branches: [ "master", "release/**" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    - uses: dotnet/nbgv@v0.4.2
+      name: NBGV
+      id: nbgv
+      with:
+        setAllVars: "true"
+
+    - name: Build Packages
+      run: dotnet build src/Uno.DebugRainbows/Uno.DebugRainbows.csproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
       id: nbgv
       with:
         setAllVars: "true"
-
+    - name: Generate Informational Version
+      id: NBGV_InformationalVersion
+      shell: pwsh
+      run: |
+        $InformationalVersion="${{ steps.nbgv.outputs.SemVer2 }}+${{ steps.nbgv.outputs.BuildingRef }}".Replace("refs/heads/","").Replace("/","-")
+        echo "Informational Version: $InformationalVersion"
+        echo "NBGV_InformationalVersion=$InformationalVersion" >> $GITHUB_ENV
     - name: Build Packages
-      run: dotnet build src/Uno.DebugRainbows/Uno.DebugRainbows.csproj
+      run: |
+        $adjustedPackageVersion="${{ steps.nbgv.outputs.SemVer2 }}".ToLower();
+        dotnet build src/Uno.DebugRainbows/Uno.DebugRainbows.csproj -c Release -p:PackageVersion=$adjustedPackageVersion -p:Version=${{ steps.nbgv.outputs.SimpleVersion }} /bl:./artifacts/debugrainbows-pack.binlog -o ./artifacts
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-packages
+        path: ./artifacts

--- a/version.json
+++ b/version.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0-dev.{height}",
+  "nuGetPackageVersion": {
+    "semVer": 2.0
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "setAllVariables": true,
+    "buildNumber": {
+      "enabled": true
+    }
+  },
+  "release": {
+    "branchName": "release/stable/{version}",
+    "firstUnstableTag": "dev"
+  }
+}


### PR DESCRIPTION
This pull request introduces a continuous integration (CI) workflow for building and packaging a .NET project, adds an action for publishing packages to nuget.org, and establishes versioning using Nerdbank.GitVersioning. These updates automate the build, versioning, and deployment process for the project.

**CI/CD Workflow Enhancements:**

- Added a new GitHub Actions workflow in `.github/workflows/ci.yml` to build the project, generate version information, package the output, and upload build artifacts for all pushes and pull requests to `master` and `release/**` branches.
- Introduced a reusable composite GitHub Action in `.github/actions/nuget-org-publish/action.yml` for deploying built NuGet packages to nuget.org, which downloads artifacts and pushes them using a provided token.

**Versioning Improvements:**

- Added `version.json` to configure Nerdbank.GitVersioning, enabling automated semantic versioning, public release branch specifications, and build number generation for consistent package versioning.