### PR TITLE
ci: adjust nuget path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,12 @@ jobs:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
       # Build your artifacts/my-sdk.nupkg package here
     
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts
+
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
         uses: NuGet/login@v1
@@ -135,7 +141,12 @@ jobs:
     
     steps:
       # Build your artifacts/my-sdk.nupkg package here
-    
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts
+
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
         uses: NuGet/login@v1


### PR DESCRIPTION
This pull request updates the CI workflow to ensure that NuGet package artifacts are downloaded before publishing steps in the pipeline. The main change is the addition of steps to download the `nuget-packages` artifact into the `./artifacts` directory in relevant jobs.

Workflow improvements:

* Added a `Download Artifacts` step using `actions/download-artifact@v4` to retrieve the `nuget-packages` artifact before publishing in both relevant jobs in `.github/workflows/ci.yml`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR97-R102) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR144-R148)