### PR TITLE
chore: set package id

### DIFF
--- a/src/Uno.DebugRainbows/Uno.DebugRainbows.csproj
+++ b/src/Uno.DebugRainbows/Uno.DebugRainbows.csproj
@@ -7,7 +7,7 @@
 	<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-
+	<PackageId>Uno.DebugRainbows</PackageId>
 	<!--
 	  UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
 	  https://aka.platform.uno/singleproject-features


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `Uno.DebugRainbows` project file. The change explicitly sets the `PackageId` property, which helps ensure the NuGet package is correctly identified during packaging and publishing processes.

* Project configuration:
  * Added the `<PackageId>` property with value `Uno.DebugRainbows` to the `Uno.DebugRainbows.csproj` file.