### PR TITLE
Add NuGet version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 # Uno DebugRainbows
 
+[![NuGet Version](https://img.shields.io/nuget/v/DebugRainbows.Uno?logo=nuget&label=NuGet)](https://www.nuget.org/packages/DebugRainbows.Uno)
+
 An [Uno Platform](https://github.com/unoplatform/uno) port of Steven Thewissen's [Xamarin.Forms.DebugRainbows](https://github.com/sthewissen/Xamarin.Forms.DebugRainbows)


### PR DESCRIPTION
This pull request adds a NuGet version badge to the `README.md` file, making it easier to see the current published version of the `DebugRainbows.Uno` package.

* Documentation update:
  * Added a NuGet version badge with a link to the package on nuget.org at the top of `README.md`.