### PR TITLE
chore: remove debug checks

### DIFF
--- a/src/Uno.DebugRainbows/DebugRainbow.cs
+++ b/src/Uno.DebugRainbows/DebugRainbow.cs
@@ -10,14 +10,11 @@ public static partial class DebugRainbow
 
 	private static void OnTomatoChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 	{
-#if DEBUG
 		IterateChildren(dependencyObject as UIElement, tomato: (bool)args.NewValue);
-#endif
 	}
 
 	private static void OnShowDebugModeChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 	{
-#if DEBUG
 		var showGrid = GetShowGrid(dependencyObject);
 		var showColors = GetShowColors(dependencyObject);
 
@@ -41,22 +38,18 @@ public static partial class DebugRainbow
 				fe.SizeChanged -= Element_SizeChanged;
 			}
 		}
-#endif
 	}
 
 	private static void Element_SizeChanged(object sender, SizeChangedEventArgs args)
 	{
-#if DEBUG
 		if (sender is Page page)
 		{
 			BuildGrid(page);
 		}
-#endif
 	}
 
 	private static void Element_Loaded(object sender, RoutedEventArgs e)
 	{
-#if DEBUG
 		if (GetShowColors(sender as DependencyObject))
 		{
 			IterateChildren(sender as UIElement);
@@ -69,7 +62,6 @@ public static partial class DebugRainbow
 				BuildGrid(page);
 			}
 		}
-#endif
 	}
 
 	private static void IterateChildren(UIElement element, bool tomato = false)


### PR DESCRIPTION
This pull request removes `#if DEBUG` preprocessor directives from several methods in the `DebugRainbow` class, making debug-related code execute in all builds, not just debug builds.

**Debug code execution changes:**

* Removed `#if DEBUG` guards from the `OnTomatoChanged`, `OnShowDebugModeChanged`, `Element_SizeChanged`, and `Element_Loaded` methods in `DebugRainbow.cs`, so their logic will now run in all build configurations. [[1]](diffhunk://#diff-05d8dcb66977055fcdf0c14067646e3d8461b047bdbfa854d8c91f536dbffd62L13-L20) [[2]](diffhunk://#diff-05d8dcb66977055fcdf0c14067646e3d8461b047bdbfa854d8c91f536dbffd62L44-L59) [[3]](diffhunk://#diff-05d8dcb66977055fcdf0c14067646e3d8461b047bdbfa854d8c91f536dbffd62L72)